### PR TITLE
Add context menu item as alternative to on-page button

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,0 +1,34 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow will install Deno then run Deno lint and test.
+# For more information see: https://github.com/denoland/setup-deno
+
+name: Deno
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v2
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
+      #- name: Verify formatting
+      #  run: deno fmt --check
+
+      - name: Run linter
+        run: deno lint

--- a/manifest.json
+++ b/manifest.json
@@ -1,20 +1,25 @@
 {
+  "manifest_version": 2,
+  "name": "OpenInSteam",
+  "version": "1.2",
 
-    "manifest_version": 2,
-    "name": "OpenInSteam",
-    "version": "1.2",
-  
-    "description": "Adds a button to open the current Steam page inside Steam.",
-  
-    "icons": {
-      "48": "icons/openinsteam-48.png"
-    },  
+  "description": "Adds a button to open the current Steam page inside Steam.",
 
-    "content_scripts": [
-      {
-        "exclude_matches": ["*://store.steampowered.com/cart/*", "*://store.steampowered.com/checkout/*"],
-        "matches": ["*://store.steampowered.com/*", "*://steamcommunity.com/*"],
-        "js": ["openinsteam.js"]
-      }
-    ]
-  }
+  "icons": {
+    "48": "icons/openinsteam-48.png"
+  },
+  "permissions": ["menus", "tabs"],
+  "background": {
+    "scripts": ["openinsteam-bg.js"]
+  },
+  "content_scripts": [
+    {
+      "exclude_matches": [
+        "*://store.steampowered.com/cart/*",
+        "*://store.steampowered.com/checkout/*"
+      ],
+      "matches": ["*://store.steampowered.com/*", "*://steamcommunity.com/*"],
+      "js": ["openinsteam.js"]
+    }
+  ]
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "OpenInSteam",
-  "version": "1.2",
+  "version": "1.3",
 
   "description": "Adds a button to open the current Steam page inside Steam.",
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "OpenInSteam",
-  "version": "1.3",
+  "version": "1.2",
 
   "description": "Adds a button to open the current Steam page inside Steam.",
 

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
   "icons": {
     "48": "icons/openinsteam-48.png"
   },
-  "permissions": ["menus", "tabs"],
+  "permissions": ["contextMenus", "tabs"],
   "background": {
     "scripts": ["openinsteam-bg.js"]
   },
@@ -18,7 +18,11 @@
         "*://store.steampowered.com/cart/*",
         "*://store.steampowered.com/checkout/*"
       ],
-      "matches": ["*://store.steampowered.com/*", "*://steamcommunity.com/*"],
+      "matches": [
+        "*://store.steampowered.com/*",
+        "*://steamcommunity.com/*",
+        "*://help.steampowered.com/*"
+      ],
       "js": ["openinsteam.js"]
     }
   ]

--- a/openinsteam-bg.js
+++ b/openinsteam-bg.js
@@ -1,0 +1,32 @@
+async function getCurrentTabUrl() {
+  return new Promise((resolve, reject) => {
+    browser.tabs
+      .query({ currentWindow: true, active: true })
+      .then((tabs) => {
+        const currentUrl = tabs[0].url;
+        return resolve(currentUrl);
+      })
+      .catch(reject);
+  });
+}
+
+const urlMatches = browser.runtime.getManifest().content_scripts[0].matches;
+
+browser.menus.create({
+  id: "open-in-steam",
+  title: "Open in Steam",
+  contexts: ["all"],
+  documentUrlPatterns: urlMatches,
+});
+
+browser.menus.onClicked.addListener(function (info) {
+  if (info.menuItemId == "open-in-steam") {
+    getCurrentTabUrl()
+      .then((url) => {
+        window.location.href = `steam://openurl/${url}`;
+      })
+      .catch(() => {
+        console.log("Failed to retrieve URL of current tab!");
+      });
+  }
+});

--- a/openinsteam-bg.js
+++ b/openinsteam-bg.js
@@ -12,14 +12,14 @@ async function getCurrentTabUrl() {
 
 const urlMatches = browser.runtime.getManifest().content_scripts[0].matches;
 
-browser.menus.create({
+browser.contextMenus.create({
   id: "open-in-steam",
   title: "Open in Steam",
   contexts: ["all"],
   documentUrlPatterns: urlMatches,
 });
 
-browser.menus.onClicked.addListener(function (info) {
+browser.contextMenus.onClicked.addListener(function (info) {
   if (info.menuItemId == "open-in-steam") {
     getCurrentTabUrl()
       .then((url) => {

--- a/openinsteam-bg.js
+++ b/openinsteam-bg.js
@@ -1,4 +1,4 @@
-async function getCurrentTabUrl() {
+function getCurrentTabUrl() {
   return new Promise((resolve, reject) => {
     browser.tabs
       .query({ currentWindow: true, active: true })


### PR DESCRIPTION
This extension is really great, but I really want the ability to have the context menu item because it's faster for me than clicking the button. I think users would like to have either option. It didn't make sense for me to submit yet another 'open in steam' extension so hopefully you'd be willing to implement this functionality into this project.